### PR TITLE
Fixing no-global-jquery to include references to `jQuery`

### DIFF
--- a/guides/rules/no-global-jquery.md
+++ b/guides/rules/no-global-jquery.md
@@ -1,6 +1,6 @@
 # No Global jQuery
 
-**TL;DR** Do not use global `$`. Use `Ember.$` instead.
+**TL;DR** Do not use global `$` or `jQuery`. Use `Ember.$` instead.
 
 In general, we want application code to reference the version of jQuery that's been directly pinned
 to the version of Ember used. This helps avoid version conflicts, and ensures that code inside modules

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -4,16 +4,18 @@
  */
 'use strict';
 
+const ALIASES = ['$', 'jQuery'];
+
 /**
- * Determines if this expression matches a global jQuery invocation.
+ * Determines if this expression matches a global jQuery invocation, either `$` or `jQuery`.
  * @param {ASTNode} node The identifier node.
  * @returns {Boolean} Returns true if the expression matches, otherwise false.
  */
 function isGlobalJquery(node) {
-  return node.callee && node.callee.name === '$';
+  return node.callee && ALIASES.includes(node.callee.name);
 }
 
-const MESSAGE = 'Do not use global `$`. Use `Ember.$` instead. Please see the following guide for more information: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-global-jquery.md';
+const MESSAGE = 'Do not use global `$` or `jQuery`. Use `Ember.$` instead. Please see the following guide for more information: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-global-jquery.md';
 
 module.exports = {
   docs: {

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -90,6 +90,38 @@ ruleTester.run('no-global-jquery', rule, {
       errors: [{
         message: MESSAGE
       }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.el = jQuery('.test');
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            invalid1() {
+              this.inv1 = jQuery('.invalid1');
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
     }
   ]
 });


### PR DESCRIPTION
The `no-global-jquery` rule was missing testing for `jQuery` in addition to `$`. This PR fixes that.

