### PR TITLE
Adding new rule: require-ember-lifeline

### DIFF
--- a/guides/rules/require-ember-lifeline.md
+++ b/guides/rules/require-ember-lifeline.md
@@ -4,43 +4,6 @@
 
 Ember applications have long life-cycles. A user may navigate to several pages and use many different features before they leave the application. This makes JavaScript and Ember development unlike Rails development, where the lifecycle of a request is short and the environment disposed of after each request. It makes Ember development much more like iOS or video game development than traditional server-side web development.
 
-It is good to note that this isn't something inherent to just Ember. Any single-page app framework or solution (Angular, React, Vue, Backbone...) must deal this lifecycles of objects, and specifically with how async tasks can be bounded by a lifecycle.
+It is good to note that this isn't something inherent to just Ember. Any single-page app framework or solution (Angular, React, Vue, Backbone...) must deal with the lifecycles of objects, and specifically with how async tasks can be bounded by a lifecycle.
 
-Ember lifeline introduces several utility methods to help manage async, object lifecycles, and the Ember runloop. Of those utility methods, `runTask` can be used as a direct replacement for `Ember.run.later`, providing engineers a more robust, lifecyle aware variant for deferred operations.
-
-Example:
-
-```javascript
-import Ember from 'ember';
-
-const { Component, run } = Ember;
-
-export default Component.extend({
-  init() {
-    this._super();
-    run.later(() => {
-      // First, check if this object is even valid
-      if (this.isDestroying || this.isDestroyed) { return; }
-      this.set('date', new Date);
-    }, 500);
-  }
-});
-```
-
-becomes:
-
-```javascript
-import Ember from 'ember';
-import RunMixin from 'ember-lifeline/mixins/run';
-
-const { Component } = Ember;
-
-export default Component.extend(RunMixin, {
-  init() {
-    this._super();
-    this.runTask(() => {
-      this.set('date', new Date);
-    }, 500);
-  }
-});
-```
+Ember lifeline introduces several utility methods to help manage async, object lifecycles, and the Ember runloop. Please review the documentation to understand the APIs that can be used to replace the equivalent `Ember.run` method.

--- a/guides/rules/require-ember-lifeline.md
+++ b/guides/rules/require-ember-lifeline.md
@@ -1,0 +1,46 @@
+# Require Ember Lifeline
+
+[Ember lifeline](https://github.com/rwjblue/ember-lifeline)
+
+Ember applications have long life-cycles. A user may navigate to several pages and use many different features before they leave the application. This makes JavaScript and Ember development unlike Rails development, where the lifecycle of a request is short and the environment disposed of after each request. It makes Ember development much more like iOS or video game development than traditional server-side web development.
+
+It is good to note that this isn't something inherent to just Ember. Any single-page app framework or solution (Angular, React, Vue, Backbone...) must deal this lifecycles of objects, and specifically with how async tasks can be bounded by a lifecycle.
+
+Ember lifeline introduces several utility methods to help manage async, object lifecycles, and the Ember runloop. Of those utility methods, `runTask` can be used as a direct replacement for `Ember.run.later`, providing engineers a more robust, lifecyle aware variant for deferred operations.
+
+Example:
+
+```javascript
+import Ember from 'ember';
+
+const { Component, run } = Ember;
+
+export default Component.extend({
+  init() {
+    this._super();
+    run.later(() => {
+      // First, check if this object is even valid
+      if (this.isDestroying || this.isDestroyed) { return; }
+      this.set('date', new Date);
+    }, 500);
+  }
+});
+```
+
+becomes:
+
+```javascript
+import Ember from 'ember';
+import RunMixin from 'ember-lifeline/mixins/run';
+
+const { Component } = Ember;
+
+export default Component.extend(RunMixin, {
+  init() {
+    this._super();
+    this.runTask(() => {
+      this.set('date', new Date);
+    }, 500);
+  }
+});
+```

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -31,7 +31,7 @@ function mergeDisallowedCalls(objects) {
 
 module.exports = {
   docs: {
-    description: 'Please use runTask from ember-lifeline instead of Ember.run.later.',
+    description: 'Please use the lifecycle-aware tasks from ember-lifeline instead of Ember.run.*.',
     category: 'Best Practices',
     recommended: false
   },

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -1,0 +1,48 @@
+/**
+ * @fileOverview Require the use of ember-lifeline's runTask over using Ember.run.later.
+ * @author Steve Calvert
+ */
+
+const { getCaller, cleanCaller } = require('../utils/caller');
+const { getEmberImportBinding } = require('../utils/imports');
+const { collectObjectPatternBindings } = require('../utils/destructed-binding');
+
+let LATER_PATTERNS = ['Ember.run.later', 'run.later'];
+
+const MESSAGE = 'Please use runTask from ember-lifeline in favor of Ember.run.later.';
+
+module.exports = {
+  docs: {
+    description: 'Please use runTask from ember-lifeline in favor of Ember.run.later.',
+    category: 'Best Practices',
+    recommended: false
+  },
+  meta: {
+    message: MESSAGE
+  },
+  create(context) {
+    let emberImportBinding;
+
+    return {
+      ObjectPattern(node) {
+        if (emberImportBinding) {
+          LATER_PATTERNS = LATER_PATTERNS.concat(collectObjectPatternBindings(node, {
+            [emberImportBinding]: ['run']
+          }));
+        }
+      },
+
+      ImportDefaultSpecifier(node) {
+        emberImportBinding = getEmberImportBinding(node);
+      },
+
+      MemberExpression(node) {
+        let caller = cleanCaller(getCaller(node));
+
+        if (LATER_PATTERNS.includes(caller)) {
+          context.report(node, MESSAGE);
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -11,11 +11,11 @@ let DISALLOWED_OBJECTS = ['Ember.run', 'run'];
 let RUN_METHODS = ['later', 'debounce', 'throttle'];
 const LIFELINE_METHODS = ['runTask', 'debounceTask', 'throttleTask'];
 
-function getMessage(caller) {
-  let method = caller.split('.').pop();
+function getMessage(actualMethodUsed) {
+  let method = actualMethodUsed.split('.').pop();
   let lifelineEquivalent = LIFELINE_METHODS[RUN_METHODS.indexOf(method)];
 
-  return `Please use ${lifelineEquivalent} from ember-lifeline instead of ${caller}.`;
+  return `Please use ${lifelineEquivalent} from ember-lifeline instead of ${actualMethodUsed}.`;
 }
 
 function mergeDisallowedCalls(objects) {

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -1,6 +1,5 @@
 /**
  * @fileOverview Require the use of ember-lifeline's lifecycle aware methods over Ember.run.*.
- * @author Steve Calvert
  */
 
 const { getCaller, cleanCaller } = require('../utils/caller');

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -1,5 +1,5 @@
 /**
- * @fileOverview Require the use of ember-lifeline's runTask over using Ember.run.later.
+ * @fileOverview Require the use of ember-lifeline's lifecycle aware methods over Ember.run.*.
  * @author Steve Calvert
  */
 
@@ -7,40 +7,63 @@ const { getCaller, cleanCaller } = require('../utils/caller');
 const { getEmberImportBinding } = require('../utils/imports');
 const { collectObjectPatternBindings } = require('../utils/destructed-binding');
 
-let LATER_PATTERNS = ['Ember.run.later', 'run.later'];
+let DISALLOWED_OBJECTS = ['Ember.run', 'run'];
+let RUN_METHODS = ['later', 'debounce', 'throttle'];
+const LIFELINE_METHODS = ['runTask', 'debounceTask', 'throttleTask'];
 
-const MESSAGE = 'Please use runTask from ember-lifeline in favor of Ember.run.later.';
+function getMessage(caller) {
+  let method = caller.split('.').pop();
+  let lifelineEquivalent = LIFELINE_METHODS[RUN_METHODS.indexOf(method)];
+
+  return `Please use ${lifelineEquivalent} from ember-lifeline instead of ${caller}.`;
+}
+
+function mergeDisallowedCalls(objects) {
+  return objects
+    .reduce((calls, obj) => {
+      RUN_METHODS.forEach((method) => {
+        calls.push(`${obj}.${method}`);
+      });
+
+      return calls;
+    }, []);
+}
 
 module.exports = {
   docs: {
-    description: 'Please use runTask from ember-lifeline in favor of Ember.run.later.',
+    description: 'Please use runTask from ember-lifeline instead of Ember.run.later.',
     category: 'Best Practices',
     recommended: false
   },
   meta: {
-    message: MESSAGE
+    message: getMessage
   },
   create(context) {
     let emberImportBinding;
+    let disallowedCalls = mergeDisallowedCalls(DISALLOWED_OBJECTS);
 
     return {
-      ObjectPattern(node) {
-        if (emberImportBinding) {
-          LATER_PATTERNS = LATER_PATTERNS.concat(collectObjectPatternBindings(node, {
-            [emberImportBinding]: ['run']
-          }));
-        }
-      },
-
       ImportDefaultSpecifier(node) {
         emberImportBinding = getEmberImportBinding(node);
+      },
+
+      ObjectPattern(node) {
+        if (emberImportBinding) {
+          disallowedCalls = disallowedCalls.concat(
+            mergeDisallowedCalls(
+              collectObjectPatternBindings(node, {
+                [emberImportBinding]: ['run']
+              })
+            )
+          );
+        }
       },
 
       MemberExpression(node) {
         let caller = cleanCaller(getCaller(node));
 
-        if (LATER_PATTERNS.includes(caller)) {
-          context.report(node, MESSAGE);
+        if (disallowedCalls.includes(caller)) {
+          context.report(node, getMessage(caller));
         }
       }
     };

--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -7,8 +7,8 @@ const { getEmberImportBinding } = require('../utils/imports');
 const { collectObjectPatternBindings } = require('../utils/destructed-binding');
 
 let DISALLOWED_OBJECTS = ['Ember.run', 'run'];
-let RUN_METHODS = ['later', 'debounce', 'throttle'];
-const LIFELINE_METHODS = ['runTask', 'debounceTask', 'throttleTask'];
+let RUN_METHODS = ['later', 'next', 'debounce', 'throttle'];
+const LIFELINE_METHODS = ['runTask', 'runTask', 'debounceTask', 'throttleTask'];
 
 function getMessage(actualMethodUsed) {
   let method = actualMethodUsed.split('.').pop();

--- a/tests/lib/rules/require-ember-lifeline.js
+++ b/tests/lib/rules/require-ember-lifeline.js
@@ -103,7 +103,7 @@ ruleTester.run('require-ember-lifeline', rule, {
           init() {
             Ember.run.later(() => {
               doSomeWork();
-            });
+            }, 100);
           }
         });`,
       parserOptions,
@@ -120,7 +120,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             foo() {
               Ember.run.later(() => {
                 doSomeWork();
-              });
+              }, 100);
             }
           }
         });`,
@@ -137,7 +137,7 @@ ruleTester.run('require-ember-lifeline', rule, {
           init() {
             run.later(() => {
               doSomeWork();
-            });
+            }, 100);
           }
         });`,
       parserOptions,
@@ -154,7 +154,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             foo() {
               run.later(() => {
                 doSomeWork();
-              });
+              }, 100);
             }
           }
         });`,
@@ -175,7 +175,7 @@ ruleTester.run('require-ember-lifeline', rule, {
           init() {
             foo.later(() => {
               doSomeWork();
-            });
+            }, 100);
           }
         });`,
       parserOptions,
@@ -196,13 +196,123 @@ ruleTester.run('require-ember-lifeline', rule, {
             bar() {
               foo.later(() => {
                 doSomeWork();
-              });
+              }, 100);
             }
           }
         });`,
       parserOptions,
       errors: [{
         message: getMessage('foo.later')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            Ember.run.next(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('Ember.run.next')
+      }]
+    },
+    {
+      code: `        
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              Ember.run.next(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('Ember.run.next')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            run.next(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('run.next')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              run.next(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('run.next')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          init() {
+            foo.next(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('foo.next')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            bar() {
+              foo.next(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: getMessage('foo.next')
       }]
     },
     {

--- a/tests/lib/rules/require-ember-lifeline.js
+++ b/tests/lib/rules/require-ember-lifeline.js
@@ -1,5 +1,5 @@
 const rule = require('../../../lib/rules/require-ember-lifeline');
-const MESSAGE = rule.meta.message;
+const getMessage = rule.meta.message;
 const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester();
 
@@ -7,6 +7,8 @@ ruleTester.run('require-ember-lifeline', rule, {
   valid: [
     {
       code: `
+        import Ember from 'ember';
+
         export default Ember.Component({
           init() {
             this.runTask(() => {
@@ -21,10 +23,80 @@ ruleTester.run('require-ember-lifeline', rule, {
     },
     {
       code: `
+        import Ember from 'ember';
+
         export default Ember.Component({
           actions: {
             foo() {
               this.runTask(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            this.debounceTask(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              this.debounceTask(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            this.throttleTask(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              this.throttleTask(() => {
                 doSomeWork();
               });
             }
@@ -39,6 +111,8 @@ ruleTester.run('require-ember-lifeline', rule, {
   invalid: [
     {
       code: `
+        import Ember from 'ember';
+
         export default Ember.Component({
           init() {
             Ember.run.later(() => {
@@ -51,11 +125,13 @@ ruleTester.run('require-ember-lifeline', rule, {
         sourceType: 'module'
       },
       errors: [{
-        message: MESSAGE
+        message: getMessage('Ember.run.later')
       }]
     },
     {
-      code: `
+      code: `        
+        import Ember from 'ember';
+
         export default Ember.Component({
           actions: {
             foo() {
@@ -70,11 +146,13 @@ ruleTester.run('require-ember-lifeline', rule, {
         sourceType: 'module'
       },
       errors: [{
-        message: MESSAGE
+        message: getMessage('Ember.run.later')
       }]
     },
     {
       code: `
+        import Ember from 'ember';
+
         export default Ember.Component({
           init() {
             run.later(() => {
@@ -87,11 +165,13 @@ ruleTester.run('require-ember-lifeline', rule, {
         sourceType: 'module'
       },
       errors: [{
-        message: MESSAGE
+        message: getMessage('run.later')
       }]
     },
     {
       code: `
+        import Ember from 'ember';
+
         export default Ember.Component({
           actions: {
             foo() {
@@ -106,7 +186,311 @@ ruleTester.run('require-ember-lifeline', rule, {
         sourceType: 'module'
       },
       errors: [{
-        message: MESSAGE
+        message: getMessage('run.later')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          init() {
+            foo.later(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.later')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            bar() {
+              foo.later(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.later')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            Ember.run.debounce(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('Ember.run.debounce')
+      }]
+    },
+    {
+      code: `        
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              Ember.run.debounce(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('Ember.run.debounce')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            run.debounce(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('run.debounce')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              run.debounce(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('run.debounce')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          init() {
+            foo.debounce(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.debounce')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            bar() {
+              foo.debounce(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.debounce')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            Ember.run.throttle(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('Ember.run.throttle')
+      }]
+    },
+    {
+      code: `        
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              Ember.run.throttle(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('Ember.run.throttle')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          init() {
+            run.throttle(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('run.throttle')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        export default Ember.Component({
+          actions: {
+            foo() {
+              run.throttle(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('run.throttle')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          init() {
+            foo.throttle(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.throttle')
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const {
+          run: foo
+        } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            bar() {
+              foo.throttle(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: getMessage('foo.throttle')
       }]
     }
   ]

--- a/tests/lib/rules/require-ember-lifeline.js
+++ b/tests/lib/rules/require-ember-lifeline.js
@@ -1,0 +1,113 @@
+const rule = require('../../../lib/rules/require-ember-lifeline');
+const MESSAGE = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-ember-lifeline', rule, {
+  valid: [
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.runTask(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            foo() {
+              this.runTask(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            Ember.run.later(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            foo() {
+              Ember.run.later(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            run.later(() => {
+              doSomeWork();
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            foo() {
+              run.later(() => {
+                doSomeWork();
+              });
+            }
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    }
+  ]
+});

--- a/tests/lib/rules/require-ember-lifeline.js
+++ b/tests/lib/rules/require-ember-lifeline.js
@@ -2,6 +2,10 @@ const rule = require('../../../lib/rules/require-ember-lifeline');
 const getMessage = rule.meta.message;
 const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester();
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module'
+};
 
 ruleTester.run('require-ember-lifeline', rule, {
   valid: [
@@ -16,10 +20,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     },
     {
       code: `
@@ -34,10 +35,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     },
     {
       code: `
@@ -50,10 +48,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     },
     {
       code: `
@@ -68,10 +63,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     },
     {
       code: `
@@ -84,10 +76,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     },
     {
       code: `
@@ -102,10 +91,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      }
+      parserOptions
     }
   ],
   invalid: [
@@ -120,10 +106,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.later')
       }]
@@ -141,10 +124,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.later')
       }]
@@ -160,10 +140,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.later')
       }]
@@ -181,10 +158,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.later')
       }]
@@ -204,10 +178,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.later')
       }]
@@ -229,10 +200,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.later')
       }]
@@ -248,10 +216,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.debounce')
       }]
@@ -269,10 +234,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.debounce')
       }]
@@ -288,10 +250,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.debounce')
       }]
@@ -309,10 +268,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.debounce')
       }]
@@ -332,10 +288,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.debounce')
       }]
@@ -357,10 +310,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.debounce')
       }]
@@ -376,10 +326,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.throttle')
       }]
@@ -397,10 +344,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('Ember.run.throttle')
       }]
@@ -416,10 +360,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.throttle')
       }]
@@ -437,10 +378,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('run.throttle')
       }]
@@ -460,10 +398,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             });
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.throttle')
       }]
@@ -485,10 +420,7 @@ ruleTester.run('require-ember-lifeline', rule, {
             }
           }
         });`,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
+      parserOptions,
       errors: [{
         message: getMessage('foo.throttle')
       }]


### PR DESCRIPTION
This rule identifies the use of `Ember.run.*` and indicates the requirement to use `runTask`, `debounceTask`, or `throttleTask` from ember-lifeline in favor of the run variant. 