### PR TITLE
Implements rule to catch send calls

### DIFF
--- a/config/experimental.js
+++ b/config/experimental.js
@@ -13,6 +13,7 @@ module.exports = {
   rules: {
     // Experimental rules
     'ember-best-practices/no-2.0.0-hooks': 2,
-    'ember-best-practices/no-send-action': 2
+    'ember-best-practices/no-send-action': 2,
+    'ember-best-practices/no-send': 2
   }
 };

--- a/guides/rules/no-send.md
+++ b/guides/rules/no-send.md
@@ -1,0 +1,9 @@
+# No send()
+
+**TL;DR: Use closure actions instead of bubbling actions via send**
+
+Before v1.13 Ember's only way to deal with actions was through a bubbling system by calling `sendAction` or `send`. This changed when closure actions got introduced into the system and changed the paradigm to simpler JS function calls.
+
+References:
+[Ember 1.13 release post](http://emberjs.com/blog/2015/06/12/ember-1-13-0-released.html#toc_closure-actions)
+[Ember Best Practices: Stop bubbling actions and use closure actions by Dan McClain](https://dockyard.com/blog/2015/10/29/ember-best-practice-stop-bubbling-and-use-closure-actions)

--- a/lib/rules/no-send.js
+++ b/lib/rules/no-send.js
@@ -1,0 +1,30 @@
+/**
+ * @fileOverview Disallow use of send
+ */
+'use strict';
+
+const { getCaller, cleanCaller } = require('../utils/caller');
+
+const SEND_CALLER = 'this.send';
+
+const MESSAGE = 'Do not use send() to bubble actions. Consider using closure actions to work with JS functions instead of relying on the old action system. Please see following guide for more information: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-send.md';
+
+module.exports = {
+  docs: {
+    description: 'Disallow use of send',
+    category: 'Best Practices'
+  },
+  meta: {
+    message: MESSAGE
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const caller = cleanCaller(getCaller(node));
+        if (caller === SEND_CALLER) {
+          context.report(node, MESSAGE);
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-send.js
+++ b/tests/lib/rules/no-send.js
@@ -1,0 +1,70 @@
+const rule = require('../../../lib/rules/no-send');
+const MESSAGE = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-send', rule, {
+  valid: [
+    {
+      code: `
+        function anotherFunction() {
+        }
+
+        export default Ember.Component({
+          actions: {
+            userInput() {
+              anotherFunction();
+              this.myAction();
+              someObj.send();
+            }
+          }
+        });`
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            userInput() {
+              this.send('myAction');
+            }
+          }
+        });`,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            userInput() {
+              this.send.apply(this, ['myAction']);
+            }
+          }
+        });`,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            userInput() {
+              this.send.call(this, 'myAction');
+            }
+          }
+        });`,
+      errors: [{
+        message: MESSAGE
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
In this PR I'm tackling the second part of #14 to catch calls using `send` to bubble actions. It follows the same approach as the previous PR to handle `sendAction` calls. 