### PR TITLE
No anonymous functions for scheduleOnce or once

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -12,6 +12,7 @@ module.exports = {
   rules: {
     // Custom rules
     'ember-best-practices/no-side-effect-cp': 2,
+    'ember-best-practices/no-anonymous-once': 2,
     'ember-best-practices/no-attrs': 2,
     'ember-best-practices/no-observers': 2,
     'ember-best-practices/require-dependent-keys': 2,

--- a/lib/rules/no-anonymous-once.js
+++ b/lib/rules/no-anonymous-once.js
@@ -1,0 +1,126 @@
+/**
+ * @fileOverview Disallow the use of anonymous functions passed to scheduleOnce and once.
+ */
+'use strict';
+
+const { getCaller, cleanCaller, isCallingWithApply, isCallingWithCall } = require('../utils/caller');
+const { collectObjectPatternBindings } = require('../utils/destructed-binding');
+const { getEmberImportBinding } = require('../utils/imports');
+const MESSAGE
+  = `The uniqueness once offers is based on function uniqueness, each invocation of this line will always create a new
+     function instance, resulting in uniqueness checks, that will never be hit. Please replace with a named function.
+     Reference: https://emberjs.com/api/ember/2.14/namespaces/Ember.run/methods/scheduleOnce?anchor=scheduleOnce`;
+
+const DISALLOWED_OBJECTS = ['Ember.run', 'run'];
+const SCHEDULE_ONCE = 'scheduleOnce';
+const RUN_METHODS = [SCHEDULE_ONCE, 'once'];
+
+/**
+ * Extracts the method that we are trying to run once from the list of arguments.
+ * An optional target parameter can be passed in as the first parameter so we need
+ * to check the length of the array to determine where our function is being passed in.
+ */
+function getMethodToRunOnce(args) {
+  return args.length > 1 ? args[1] : args[0];
+}
+
+/**
+ * scheduleOnce takes in the queue name as the first parameter. In this function we will remove
+ * that parameter from the array to make it look the same as the arguments to once and facilitate
+ * extracting the method that we are trying to run once out of the args.
+ */
+function normalizeArguments(caller, args) {
+  let mut = args.slice();
+
+  if (isCallingWithCall(caller)) {
+    // Whenever the action was called .call we want to remove the context parameter
+    mut.shift();
+  } else if (isCallingWithApply(caller)) {
+    // Whenever the action was called with .apply we want to get the arguments with which the function
+    // would actually get called
+    mut = mut[1].elements.slice();
+  }
+
+  // scheduleOnce takes in the queue name as the first parameter so we have to remove it have a similar
+  // structure as "once"
+  if (cleanCaller(caller).indexOf(SCHEDULE_ONCE) > -1) {
+    mut.shift();
+  }
+
+  return mut;
+}
+
+function isAnonymousFunction(fn) {
+  return fn && !fn.name;
+}
+
+function isString(node) {
+  return node.type === 'Literal' && typeof node.value === 'string';
+}
+
+function mergeDisallowedCalls(objects) {
+  return objects
+    .reduce((calls, obj) => {
+      RUN_METHODS.forEach((method) => {
+        calls.push(`${obj}.${method}`);
+      });
+
+      return calls;
+    }, []);
+}
+
+module.exports = {
+  docs: {
+    description: 'Disallow use of anonymous functions when use in scheduleOnce or once',
+    category: 'Best Practices',
+    recommended: true
+  },
+  meta: {
+    message: MESSAGE
+  },
+  create(context) {
+    let emberImportBinding;
+    let disallowedCalls = mergeDisallowedCalls(DISALLOWED_OBJECTS);
+
+    return {
+      ImportDefaultSpecifier(node) {
+        emberImportBinding = getEmberImportBinding(node);
+      },
+
+      ObjectPattern(node) {
+        if (!emberImportBinding) {
+          return;
+        }
+
+        /**
+         * Retrieves the deconstructed bindings from the Ember import, accounting for aliasing
+         * of the import.
+         */
+        disallowedCalls = disallowedCalls.concat(
+          mergeDisallowedCalls(
+            collectObjectPatternBindings(node, {
+              [emberImportBinding]: ['run']
+            })
+          )
+        );
+      },
+
+      CallExpression(node) {
+        const caller = getCaller(node);
+
+        if (!disallowedCalls.includes(cleanCaller(caller))) {
+          return;
+        }
+
+        const normalizedArguments = normalizeArguments(caller, node.arguments);
+        const fnToRunOnce = getMethodToRunOnce(normalizedArguments);
+
+        // The fnToRunceOnce is a string it means that it will be resolved on the target at the time once or
+        // scheduleOnce is invoked.
+        if (isAnonymousFunction(fnToRunOnce) && !isString(fnToRunOnce)) {
+          context.report(node, MESSAGE);
+        }
+      }
+    };
+  }
+};

--- a/lib/utils/caller.js
+++ b/lib/utils/caller.js
@@ -40,7 +40,17 @@ function cleanCaller(caller) {
   return caller;
 }
 
+function isCallingWithCall(caller) {
+  return endsWith(caller, '.call');
+}
+
+function isCallingWithApply(caller) {
+  return endsWith(caller, '.apply');
+}
+
 module.exports = {
   getCaller,
-  cleanCaller
+  cleanCaller,
+  isCallingWithApply,
+  isCallingWithCall
 };

--- a/tests/lib/rules/no-anonymous-once.js
+++ b/tests/lib/rules/no-anonymous-once.js
@@ -1,0 +1,105 @@
+const rule = require('../../../lib/rules/no-anonymous-once');
+const MESSAGE = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+});
+const errors = [{
+  message: MESSAGE
+}];
+
+ruleTester.run('no-anonymous-once', rule, {
+  valid: [
+    {
+      code: `
+        function noop() {} ;
+        export default Ember.Component({
+          perform() {
+            Ember.run.scheduleOnce('afterRender', this, noop);
+            Ember.run.scheduleOnce('afterRender', noop);
+            run.scheduleOnce('afterRender', this, noop);
+            run.scheduleOnce('afterRender', noop);
+            run.scheduleOnce.apply(this, ['afterRender', this, noop]);
+            run.scheduleOnce.apply(this, ['afterRender', noop]);
+            run.scheduleOnce.call(this, 'afterRender', this, noop);
+            run.scheduleOnce.call(this, 'afterRender', noop);
+          }
+        });`
+    },
+    {
+      code: `
+        function noop() {} ;
+        export default Ember.Component({
+          perform() {
+            Ember.run.once(this, noop);
+            Ember.run.once(noop);
+            run.once(this, noop);
+            run.once(noop);
+            run.once.apply(this, [this, noop]);
+            run.once.apply(this, [noop]);
+            run.once.call(this, this, noop);
+            run.once.call(this, noop);
+          }
+        });`
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.scheduleOnce('afterRender', () => {});
+          }
+        });`,
+      errors
+    },
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.scheduleOnce('afterRender', this, () => {});
+          }
+        });`,
+      errors
+    },
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.once(this, () => {});
+          }
+        });`,
+      errors
+    },
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.once(() => {});
+          }
+        });`,
+      errors
+    },
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.once(function () {});
+          }
+        });`,
+      errors
+    },
+    {
+      code: `
+        export default Ember.Component({
+          perform() {
+            Ember.run.scheduleOnce('afterRender', function () {});
+          }
+        });`,
+      errors
+    }
+  ]
+});


### PR DESCRIPTION
In this PR I'm adding a rule to tackle the issue brought up in #57. In this case I'm checking for function uniqueness by looking into the name property of the function and seeing if it is defined. 

This rule will only be checked when you call `Ember.run.scheduleOnce`, `run.scheduleOnce`, `Ember.run.once` and `run.once`. We could potentially also check for just calling `scheduleOnce` or `once` but wasn't to sure about which route we wanted to take this. 