### PR TITLE
Add linting for CallExpessions like $.ajax()

### DIFF
--- a/guides/rules/no-jquery-methods.md
+++ b/guides/rules/no-jquery-methods.md
@@ -2,12 +2,12 @@
 
 **TL;DR** The intent of this rule is to identify any blacklisted jQuery methods as deprecated.
 
-Provides the ability to blacklist a set of jQuery methods for deprecation. 
+Provides the ability to blacklist a set of jQuery methods for deprecation.
 The eventual goal being a complete removal of jQuery.
 
 # Usage
 
-Pass an argument array containing the specific blacklisted jQuery methods your consuming application is flagging for. 
+Pass an argument array containing the specific blacklisted jQuery methods your consuming application is flagging for.
 
 ```js
 const BLACKLIST = [
@@ -20,4 +20,10 @@ const BLACKLIST = [
 rules: {
   'ember-best-practices/no-jquery-methods': ['error', BLACKLIST]
 }
+```
+To help generate this blacklist array, you can run this snippet in the console of your app:
+```js
+// In the dev tools console of your app.
+let $methods = [...new Set(Object.keys($).concat(Object.keys($.fn)))];
+copy(`'${$methods.join('\',\r\n\'')}'`)
 ```

--- a/guides/rules/no-jquery-methods.md
+++ b/guides/rules/no-jquery-methods.md
@@ -11,13 +11,13 @@ Pass an argument array containing the specific blacklisted jQuery methods your c
 
 ```js
 const BLACKLIST = [
- -  'add',
- -  'addBack',
- -  'after',
- -  'ajaxComplete'
+  'add',
+  'addBack',
+  'after',
+  'ajaxComplete'
 ];
 
 rules: {
-  'ember-best-practices/no-jquery-methods': [2, BLACKLIST]
+  'ember-best-practices/no-jquery-methods': ['error', BLACKLIST]
 }
 ```

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -6,7 +6,7 @@
 const { get } = require('../utils/get');
 
 function getMessage(blackListName) {
-  return `The use of ${blackListName} method has been deprecated.`;
+  return `The use of jQuery's ${blackListName} method has been deprecated.`;
 }
 
 function isJQueryCaller(node, name = null) {
@@ -51,6 +51,14 @@ module.exports = {
       VariableDeclarator(node) {
         varDecIDName = get(node, 'id.name');
         jQueryLocalName = jQueryLocalName === get(node, 'init.name') ? varDecIDName : null;
+      },
+
+      CallExpression(node) {
+        const calleeName = get(node, 'callee.property.name');
+        const parentCalleeName = get(node, 'callee.object.property.name');
+        if (BLACKLIST.includes(calleeName) && parentCalleeName === '$') {
+          context.report({ node: node.callee.property, message: getMessage(`${parentCalleeName}.${calleeName}()`) });
+        }
       },
 
       MemberExpression(node) {

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -34,7 +34,25 @@ ruleTester.run('no-jquery-methods', rule, {
         export default Ember.Component({
           init() {
             const myObj = {};
-            myObj[${BLACKLISTMETHOD}]();      
+            myObj[${BLACKLISTMETHOD}]();
+          }
+        });`,
+      options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.$.notBlacklistedMethod();
+          }
+        });`,
+      options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            Ember.$.notBlacklistedMethod();
           }
         });`,
       options: [BLACKLISTMETHOD]
@@ -109,7 +127,7 @@ ruleTester.run('no-jquery-methods', rule, {
         export default Ember.Component({
           init() {
             const myJQueryObj = this.$();
-            myJQueryObj[${BLACKLISTMETHOD}]();      
+            myJQueryObj[${BLACKLISTMETHOD}]();
           }
         });`,
       options: [BLACKLISTMETHOD],
@@ -129,6 +147,30 @@ ruleTester.run('no-jquery-methods', rule, {
       options: [BLACKLISTMETHOD],
       errors: [{
         message: getMessage(BLACKLISTMETHOD)
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.$.add();
+          }
+        });`,
+      options: [BLACKLISTMETHOD],
+      errors: [{
+        message: getMessage(`$.${BLACKLISTMETHOD}()`)
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            Ember.$.add();
+          }
+        });`,
+      options: [BLACKLISTMETHOD],
+      errors: [{
+        message: getMessage(`$.${BLACKLISTMETHOD}()`)
       }]
     }
   ]


### PR DESCRIPTION
Previously `$.ajax()`, `$.params()`, `$.each()`, etc wouldn't get flagged by this rule. Now they are 😄 

Also clean up the no-jquery-method explanation a tiny bit.

@trentmwillis @chadhietala 