### PR TITLE
Remove Ember from isJQueryCaller check

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,13 +2,16 @@ Burnashov Evgeny <sham@sveak.com>
 Chad Hietala <chadhietala@gmail.com>
 Chris Thoburn <runspired@users.noreply.github.com>
 David J. Hamilton <github@hjdivad.com>
+Edilberto Ruvalcaba <eddie.ruva@gmail.com>
 Edilberto Ruvalcaba <eruvalcaba@linkedin.com>
 Ilya Radchenko <knownasilya@gmail.com>
 Justin Lan <julan@linkedin.com>
 Katie Gengler <katie@kmg.io>
 Kyle Turney <turney.kyle@gmail.com>
 Marc Lynch <lynchbomb@users.noreply.github.com>
+Marc Lynch <lynchmarc2@gmail.com>
 Mikael Riska <mikael.riska@ecraft.com>
+Nathaniel Furniss <nlfurniss@gmail.com>
 Quinn C. Hoyer <qhoyer@linkedin.com>
 Robert Jackson <me@rwjblue.com>
 Ryunosuke Sato <tricknotes.rs@gmail.com>

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -10,12 +10,11 @@ function getMessage(blackListName) {
 }
 
 function isJQueryCaller(node, name = null) {
-  let oName = get(node, 'object.callee.object.name') === 'Ember';
   let pName = get(node, 'object.callee.property.name') === '$';
   let cName = get(node, 'object.callee.name') === '$';
   let lName = get(node, 'object.name') === name;
 
-  return oName || pName || cName || lName;
+  return pName || cName || lName;
 }
 
 function getLocalImportName(node, sourceName) {

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -52,10 +52,28 @@ ruleTester.run('no-jquery-methods', rule, {
       code: `
         export default Ember.Component({
           init() {
+            Ember.$.notBlacklistedMethod();
+          }
+        });`,
+      options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
             Ember.get().add();
           }
         });`,
       options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.$().add();
+          }
+        });`,
+      options: []
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -52,7 +52,7 @@ ruleTester.run('no-jquery-methods', rule, {
       code: `
         export default Ember.Component({
           init() {
-            Ember.$.notBlacklistedMethod();
+            Ember.get().add();
           }
         });`,
       options: [BLACKLISTMETHOD]


### PR DESCRIPTION
Previously, the `no-jquery-methods` rule would trigger on this code:

```js
Ember.get(someObj, 'property')
  .filter(hasProperty)
...
```

I removed the check for `Ember` from `isJQueryCaller` and it no longer throws a false positive and tests pass. Also added a new test case

@trentmwillis @lynchbomb @scalvert