### PR TITLE
Guard propertyName in no-jquery-methods

### DIFF
--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -62,6 +62,10 @@ module.exports = {
 
       MemberExpression(node) {
         let propertyName = get(node, 'property.name');
+        // If the node doesn't have a name, return early.
+        if (!propertyName) {
+          return;
+        }
         let blackListName = BLACKLIST.includes(propertyName) ? propertyName : false;
         let isThisExpression = get(node, 'object.type').includes('ThisExpression');
 

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -74,6 +74,24 @@ ruleTester.run('no-jquery-methods', rule, {
           }
         });`,
       options: []
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            const myVar = this[this.myProp];
+          }
+        });`,
+      options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            const q = this[\`\${myVar}\`];
+          }
+        });`,
+      options: [BLACKLISTMETHOD]
     }
   ],
   invalid: [


### PR DESCRIPTION
In a large app I'm testing, the line `this[this.someProp]` was causing the no-jquery-methods rule to error out since `node.object` is a `ThisExpression` thus `node.object.property.name` was undefined.

In an [example AST gist](https://astexplorer.net/#/gist/3411251715d16588673b356090b3f032/891b5687cee2d352036edda4939c3baff044d10e) you can see this.

There is no point in continuing if `propertyName` is undefined since we base the blacklist off it. Added test cases.

@lynchbomb @chadhietala @scalvert 