### PR TITLE
Fix logic to detect jQuery being assigned to a var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/.vscode

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -4,17 +4,22 @@
 'use strict';
 
 const { get } = require('../utils/get');
+const JQUERY_ALIASES = ['$', 'jQuery'];
 
 function getMessage(blackListName) {
   return `The use of jQuery's ${blackListName} method has been deprecated.`;
 }
 
 function isJQueryCaller(node, name = null) {
-  let pName = get(node, 'object.callee.property.name') === '$';
-  let cName = get(node, 'object.callee.name') === '$';
-  let lName = get(node, 'object.name') === name;
+  const calleePropertyNameisJquery = get(node, 'object.callee.property.name') === '$';
+  const calleeNameIsJquery = get(node, 'object.callee.name') === '$';
+  const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
+  const ObjectNameisLocalJquery = get(node, 'object.name') === name;
 
-  return pName || cName || lName;
+  return calleePropertyNameisJquery
+    || calleeNameIsJquery
+    || calleeNameIsLocalJquery
+    || ObjectNameisLocalJquery;
 }
 
 function getLocalImportName(node, sourceName) {
@@ -36,7 +41,6 @@ module.exports = {
   create(context) {
     const BLACKLIST = context.options[0] || [];
     let jQueryLocalName = null;
-    let varDecIDName = null;
 
     return {
 
@@ -48,8 +52,17 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        varDecIDName = get(node, 'id.name');
-        jQueryLocalName = jQueryLocalName === get(node, 'init.name') ? varDecIDName : null;
+        const varDecIDName = get(node, 'id.name');
+        // Get the name of what was assigned to the variable.
+        const varAssignment = get(node, 'init.callee.property.name')
+          || get(node, 'init.property.name')
+          || get(node, 'init.name')
+          || '';
+        const varAssignmentIsJquery = JQUERY_ALIASES.includes(varAssignment);
+
+        if (varAssignmentIsJquery) {
+          jQueryLocalName = varDecIDName;
+        }
       },
 
       CallExpression(node) {
@@ -68,8 +81,6 @@ module.exports = {
         }
         let blackListName = BLACKLIST.includes(propertyName) ? propertyName : false;
         let isThisExpression = get(node, 'object.type').includes('ThisExpression');
-
-        jQueryLocalName = isThisExpression && propertyName.includes('$') ? varDecIDName : jQueryLocalName;
 
         if (!isThisExpression && blackListName && isJQueryCaller(node, jQueryLocalName)) {
           context.report({ node: node.property, message: getMessage(blackListName) });

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -92,6 +92,16 @@ ruleTester.run('no-jquery-methods', rule, {
           }
         });`,
       options: [BLACKLISTMETHOD]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          myFunc() {
+            const output = this.privateMethod();
+            this.$elem.style.height1 = output.height;
+          }
+        });`,
+      options: ['height']
     }
   ],
   invalid: [


### PR DESCRIPTION
There is a bug in the current `no-jquery-method` rule that mistakenly flags a method/property that has the same name as a jQuery method. It's an edgecase, but one that's already bit us.

__STR__
the rule encounters a variable (`mayVar`) then `this.$anything...`, then `myVar.forbiddenJqueryMethod` it returns an error.

@scalvert @trentmwillis @rwjblue  