### PR TITLE
Fix no-global-jquery returning false positive for var assignment #85

### DIFF
--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -2,11 +2,9 @@
  * @fileOverview Disallow the use of global `$`.
  */
 'use strict';
-
 const { getEmberImportBinding } = require('../utils/imports');
 const {
-  isJQueryCallee,
-  isVariableAssigmentJquery,
+  isVariableAssigmentGlobalJquery,
   JQUERY_ALIASES
 } = require('../utils/jquery');
 const { collectObjectPatternBindings } = require('../utils/destructed-binding');
@@ -34,7 +32,6 @@ module.exports = {
   create(context) {
     let emberImportBinding;
     let destructuredAssignment = null;
-    let jQueryLocalName = null;
 
     function isDestructured(node) {
       return node && node.callee && node.callee.name === destructuredAssignment;
@@ -54,13 +51,13 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        jQueryLocalName = isVariableAssigmentJquery(node);
+        if (isVariableAssigmentGlobalJquery(node)) {
+          context.report(node, MESSAGE);
+        }
       },
 
       CallExpression(node) {
-        if (jQueryLocalName && !isJQueryCallee(node, jQueryLocalName)) {
-          return;
-        } else if (!isDestructured(node) && isGlobalJquery(node)) {
+        if (!isDestructured(node) && isGlobalJquery(node)) {
           context.report(node, MESSAGE);
         }
       }

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -4,10 +4,14 @@
 'use strict';
 
 const { getEmberImportBinding } = require('../utils/imports');
+const {
+  isJQueryCallee,
+  isVariableAssigmentJquery,
+  JQUERY_ALIASES
+} = require('../utils/jquery');
 const { collectObjectPatternBindings } = require('../utils/destructed-binding');
 
 const MESSAGE = 'Do not use global `$` or `jQuery`.';
-const ALIASES = ['$', 'jQuery'];
 
 /**
  * Determines if this expression matches a global jQuery invocation, either `$` or `jQuery`.
@@ -15,7 +19,7 @@ const ALIASES = ['$', 'jQuery'];
  * @returns {Boolean} Returns true if the expression matches, otherwise false.
  */
 function isGlobalJquery(node) {
-  return node.callee && ALIASES.includes(node.callee.name);
+  return node.callee && JQUERY_ALIASES.includes(node.callee.name);
 }
 
 module.exports = {
@@ -30,6 +34,7 @@ module.exports = {
   create(context) {
     let emberImportBinding;
     let destructuredAssignment = null;
+    let jQueryLocalName = null;
 
     function isDestructured(node) {
       return node && node.callee && node.callee.name === destructuredAssignment;
@@ -48,8 +53,14 @@ module.exports = {
         }
       },
 
+      VariableDeclarator(node) {
+        jQueryLocalName = isVariableAssigmentJquery(node);
+      },
+
       CallExpression(node) {
-        if (!isDestructured(node) && isGlobalJquery(node)) {
+        if (jQueryLocalName && !isJQueryCallee(node, jQueryLocalName)) {
+          return;
+        } else if (!isDestructured(node) && isGlobalJquery(node)) {
           context.report(node, MESSAGE);
         }
       }

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -2,6 +2,7 @@
  * @fileOverview Disallow the use of global `$`.
  */
 'use strict';
+const { get } = require('../utils/get');
 const { getEmberImportBinding } = require('../utils/imports');
 const {
   isVariableAssigmentGlobalJquery,
@@ -32,6 +33,7 @@ module.exports = {
   create(context) {
     let emberImportBinding;
     let destructuredAssignment = null;
+    let emberJqueryVariables = [];
 
     function isDestructured(node) {
       return node && node.callee && node.callee.name === destructuredAssignment;
@@ -53,11 +55,15 @@ module.exports = {
       VariableDeclarator(node) {
         if (isVariableAssigmentGlobalJquery(node)) {
           context.report(node, MESSAGE);
+        } else {
+          const varName = get(node, 'id.name');
+          emberJqueryVariables.push(varName);
         }
       },
 
       CallExpression(node) {
-        if (!isDestructured(node) && isGlobalJquery(node)) {
+        const calleeName = get(node, 'callee.name');
+        if (!isDestructured(node) && isGlobalJquery(node) && !emberJqueryVariables.includes(calleeName)) {
           context.report(node, MESSAGE);
         }
       }

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const { get } = require('../utils/get');
-const { isJQueryCallee, isVariableAssigmentGlobalJquery } = require('../utils/jquery');
+const { isJQueryCallee, isVariableAssigmentJquery } = require('../utils/jquery');
 
 function getMessage(blackListName) {
   return `The use of jQuery's ${blackListName} method has been deprecated.`;
@@ -40,13 +40,14 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        jQueryLocalName = isVariableAssigmentGlobalJquery(node);
+        const varName = get(node, 'id.name');
+        jQueryLocalName = isVariableAssigmentJquery(node) ? varName : null;
       },
 
       CallExpression(node) {
         const calleeName = get(node, 'callee.property.name');
         const parentCalleeName = get(node, 'callee.object.property.name');
-        if (BLACKLIST.includes(calleeName) && parentCalleeName === '$') {
+        if (BLACKLIST.includes(calleeName) && (parentCalleeName === '$' || isJQueryCallee(node, jQueryLocalName))) {
           context.report({ node: node.callee.property, message: getMessage(`${parentCalleeName}.${calleeName}()`) });
         }
       },

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -4,22 +4,10 @@
 'use strict';
 
 const { get } = require('../utils/get');
-const JQUERY_ALIASES = ['$', 'jQuery'];
+const { isJQueryCallee, isVariableAssigmentJquery } = require('../utils/jquery');
 
 function getMessage(blackListName) {
   return `The use of jQuery's ${blackListName} method has been deprecated.`;
-}
-
-function isJQueryCaller(node, name = null) {
-  const calleePropertyNameisJquery = get(node, 'object.callee.property.name') === '$';
-  const calleeNameIsJquery = get(node, 'object.callee.name') === '$';
-  const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
-  const ObjectNameisLocalJquery = get(node, 'object.name') === name;
-
-  return calleePropertyNameisJquery
-    || calleeNameIsJquery
-    || calleeNameIsLocalJquery
-    || ObjectNameisLocalJquery;
 }
 
 function getLocalImportName(node, sourceName) {
@@ -52,17 +40,7 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        const varDecIDName = get(node, 'id.name');
-        // Get the name of what was assigned to the variable.
-        const varAssignment = get(node, 'init.callee.property.name')
-          || get(node, 'init.property.name')
-          || get(node, 'init.name')
-          || '';
-        const varAssignmentIsJquery = JQUERY_ALIASES.includes(varAssignment);
-
-        if (varAssignmentIsJquery) {
-          jQueryLocalName = varDecIDName;
-        }
+        jQueryLocalName = isVariableAssigmentJquery(node);
       },
 
       CallExpression(node) {
@@ -82,7 +60,7 @@ module.exports = {
         let blackListName = BLACKLIST.includes(propertyName) ? propertyName : false;
         let isThisExpression = get(node, 'object.type').includes('ThisExpression');
 
-        if (!isThisExpression && blackListName && isJQueryCaller(node, jQueryLocalName)) {
+        if (!isThisExpression && blackListName && isJQueryCallee(node, jQueryLocalName)) {
           context.report({ node: node.property, message: getMessage(blackListName) });
         }
       }

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const { get } = require('../utils/get');
+const { get, getParent } = require('../utils/get');
 const { isJQueryCallee, isVariableAssigmentJquery } = require('../utils/jquery');
 
 function getMessage(blackListName) {
@@ -28,26 +28,35 @@ module.exports = {
   },
   create(context) {
     const BLACKLIST = context.options[0] || [];
-    let jQueryLocalName = null;
+    let funcScopeJqueryVariables = [];
+    let moduleScopeJqueryVariables = [];
 
     return {
 
       ImportDeclaration(node) {
         let localName = getLocalImportName(node, 'jquery');
         if (localName.length > 0) {
-          jQueryLocalName = localName[0];
+          moduleScopeJqueryVariables.push(localName[0]);
         }
       },
 
       VariableDeclarator(node) {
-        const varName = get(node, 'id.name');
-        jQueryLocalName = isVariableAssigmentJquery(node) ? varName : null;
+        if (isVariableAssigmentJquery(node)) {
+          const varName = get(node, 'id.name');
+          const isFuncScope = !!getParent(node, (parent) => parent.type === 'FunctionDeclaration'); // Determine if variable is in function scope or global scope.
+
+          if (isFuncScope) {
+            funcScopeJqueryVariables.push(varName);
+          } else {
+            moduleScopeJqueryVariables.push(varName);
+          }
+        }
       },
 
       CallExpression(node) {
         const calleeName = get(node, 'callee.property.name');
         const parentCalleeName = get(node, 'callee.object.property.name');
-        if (BLACKLIST.includes(calleeName) && (parentCalleeName === '$' || isJQueryCallee(node, jQueryLocalName))) {
+        if (BLACKLIST.includes(calleeName) && (parentCalleeName === '$' || isJQueryCallee(node, moduleScopeJqueryVariables, funcScopeJqueryVariables))) {
           context.report({ node: node.callee.property, message: getMessage(`${parentCalleeName}.${calleeName}()`) });
         }
       },
@@ -61,9 +70,14 @@ module.exports = {
         let blackListName = BLACKLIST.includes(propertyName) ? propertyName : false;
         let isThisExpression = get(node, 'object.type').includes('ThisExpression');
 
-        if (!isThisExpression && blackListName && isJQueryCallee(node, jQueryLocalName)) {
+        if (!isThisExpression && blackListName && isJQueryCallee(node, moduleScopeJqueryVariables, funcScopeJqueryVariables)) {
           context.report({ node: node.property, message: getMessage(blackListName) });
         }
+      },
+
+      FunctionDeclaration() {
+        // Reset the function scope variables for each function declaration.
+        funcScopeJqueryVariables.length = 0;
       }
     };
   }

--- a/lib/rules/no-jquery-methods.js
+++ b/lib/rules/no-jquery-methods.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const { get } = require('../utils/get');
-const { isJQueryCallee, isVariableAssigmentJquery } = require('../utils/jquery');
+const { isJQueryCallee, isVariableAssigmentGlobalJquery } = require('../utils/jquery');
 
 function getMessage(blackListName) {
   return `The use of jQuery's ${blackListName} method has been deprecated.`;
@@ -40,7 +40,7 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        jQueryLocalName = isVariableAssigmentJquery(node);
+        jQueryLocalName = isVariableAssigmentGlobalJquery(node);
       },
 
       CallExpression(node) {

--- a/lib/utils/jquery.js
+++ b/lib/utils/jquery.js
@@ -6,27 +6,69 @@ function isJQueryCallee(node, name = null) {
   const calleePropertyNameisJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.property.name'));
   const calleeNameIsJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.name'));
   const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
-  const ObjectNameisLocalJquery = get(node, 'object.name') === name;
+  const objectNameisLocalJquery = get(node, 'object.name') === name;
 
   return calleePropertyNameisJquery
     || calleeNameIsJquery
     || calleeNameIsLocalJquery
-    || ObjectNameisLocalJquery;
+    || objectNameisLocalJquery;
 }
 
-function isVariableAssigmentGlobalJquery(node) {
-  const varDecIDName = get(node, 'id.name');
+/**
+ * Helper function that returns the name of what was assigned to the variable.
+ * @param {ASTNode} node
+ * @return {String}
+ */
+function getVarAssignmentName(node) {
   // Get the name of what was assigned to the variable.
-  const varAssignment = get(node, 'init.callee.property.name') || get(node, 'init.name');
-    // A variable's callee object's name tells us whether this is a usage of Ember.$ or global $.
-  const varCalleeObjName = get(node, 'init.callee.object.name');
-  const varAssignmentIsGlobalJquery = JQUERY_ALIASES.includes(varAssignment) && varCalleeObjName !== 'Ember';
+  return get(node, 'init.callee.property.name') || get(node, 'init.name');
+}
 
-  return varAssignmentIsGlobalJquery ? varDecIDName : null;
+/**
+ * Determines whether a variable assignment's callee is Ember/this.
+ * @param {ASTNode} node
+ * @return {Boolean}
+ */
+function isVarAssignmentCalleeEmber(node) {
+  // A variable's callee object's name tells us whether this is a usage of Ember.$ or global $.
+  const isVarCalleeObjNameEmber = get(node, 'init.callee.object.name') === 'Ember';
+  // Whether or not the callee oject is `this.$`.
+  const isVarCalleeObjThis = get(node, 'init.callee.object.type') === 'ThisExpression';
+
+  return isVarCalleeObjNameEmber || isVarCalleeObjThis;
+}
+
+/**
+ * Determines whether a variable's assignment is global jQuery.
+ * @param {ASTNode} node
+ * @return {Boolean}
+ */
+function isVariableAssigmentGlobalJquery(node) {
+  return isVariableAssigmentJquery(node) && !isVarAssignmentCalleeEmber(node);
+}
+
+/**
+ * Determines whether a variable's assignment is Ember jQuery.
+ * @param {ASTNode} node
+ * @return {Boolean}
+ */
+function isVariableAssigmentEmberJquery(node) {
+  return isVariableAssigmentJquery(node) && isVarAssignmentCalleeEmber(node);
+}
+
+/**
+ * Determines whether a variable's assignment is Ember jQuery.
+ * @param {ASTNode} node
+ * @return {Boolean}
+ */
+function isVariableAssigmentJquery(node) {
+  return JQUERY_ALIASES.includes(getVarAssignmentName(node));
 }
 
 module.exports = {
   isJQueryCallee,
   isVariableAssigmentGlobalJquery,
+  isVariableAssigmentEmberJquery,
+  isVariableAssigmentJquery,
   JQUERY_ALIASES
 };

--- a/lib/utils/jquery.js
+++ b/lib/utils/jquery.js
@@ -1,0 +1,33 @@
+const { get } = require('../utils/get');
+
+const JQUERY_ALIASES = ['$', 'jQuery'];
+
+function isJQueryCallee(node, name = null) {
+  const calleePropertyNameisJquery = get(node, 'object.callee.property.name') === '$';
+  const calleeNameIsJquery = get(node, 'object.callee.name') === '$';
+  const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
+  const ObjectNameisLocalJquery = get(node, 'object.name') === name;
+
+  return calleePropertyNameisJquery
+    || calleeNameIsJquery
+    || calleeNameIsLocalJquery
+    || ObjectNameisLocalJquery;
+}
+
+function isVariableAssigmentJquery(node) {
+  const varDecIDName = get(node, 'id.name');
+  // Get the name of what was assigned to the variable.
+  const varAssignment = get(node, 'init.callee.property.name')
+    || get(node, 'init.property.name')
+    || get(node, 'init.name')
+    || '';
+  const varAssignmentIsJquery = JQUERY_ALIASES.includes(varAssignment);
+
+  return varAssignmentIsJquery ? varDecIDName : null;
+}
+
+module.exports = {
+  isJQueryCallee,
+  isVariableAssigmentJquery,
+  JQUERY_ALIASES
+};

--- a/lib/utils/jquery.js
+++ b/lib/utils/jquery.js
@@ -3,8 +3,8 @@ const { get } = require('../utils/get');
 const JQUERY_ALIASES = ['$', 'jQuery'];
 
 function isJQueryCallee(node, name = null) {
-  const calleePropertyNameisJquery = get(node, 'object.callee.property.name') === '$';
-  const calleeNameIsJquery = get(node, 'object.callee.name') === '$';
+  const calleePropertyNameisJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.property.name'));
+  const calleeNameIsJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.name'));
   const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
   const ObjectNameisLocalJquery = get(node, 'object.name') === name;
 
@@ -14,20 +14,19 @@ function isJQueryCallee(node, name = null) {
     || ObjectNameisLocalJquery;
 }
 
-function isVariableAssigmentJquery(node) {
+function isVariableAssigmentGlobalJquery(node) {
   const varDecIDName = get(node, 'id.name');
   // Get the name of what was assigned to the variable.
-  const varAssignment = get(node, 'init.callee.property.name')
-    || get(node, 'init.property.name')
-    || get(node, 'init.name')
-    || '';
-  const varAssignmentIsJquery = JQUERY_ALIASES.includes(varAssignment);
+  const varAssignment = get(node, 'init.callee.property.name') || get(node, 'init.name');
+    // A variable's callee object's name tells us whether this is a usage of Ember.$ or global $.
+  const varCalleeObjName = get(node, 'init.callee.object.name');
+  const varAssignmentIsGlobalJquery = JQUERY_ALIASES.includes(varAssignment) && varCalleeObjName !== 'Ember';
 
-  return varAssignmentIsJquery ? varDecIDName : null;
+  return varAssignmentIsGlobalJquery ? varDecIDName : null;
 }
 
 module.exports = {
   isJQueryCallee,
-  isVariableAssigmentJquery,
+  isVariableAssigmentGlobalJquery,
   JQUERY_ALIASES
 };

--- a/lib/utils/jquery.js
+++ b/lib/utils/jquery.js
@@ -2,16 +2,24 @@ const { get } = require('../utils/get');
 
 const JQUERY_ALIASES = ['$', 'jQuery'];
 
-function isJQueryCallee(node, name = null) {
-  const calleePropertyNameisJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.property.name'));
-  const calleeNameIsJquery = JQUERY_ALIASES.includes(get(node, 'object.callee.name'));
-  const calleeNameIsLocalJquery = get(node, 'object.callee.name') === name;
-  const objectNameisLocalJquery = get(node, 'object.name') === name;
+/**
+ * Determines whether a given node's callee is jQuery.
+ * @param {ASTNode} node
+ * @param {...Array} localJqueryVars Array(s) of local variables that have jQuery assigned to them.
+ * @return {Boolean}
+ */
+function isJQueryCallee(node, ...localJqueryVars) {
+  const allJqueryAliases = localJqueryVars.reduce((accumulator, newArray) => {
+    return accumulator.concat(newArray);
+  }, JQUERY_ALIASES);
+
+  const calleePropertyNameisJquery = allJqueryAliases.includes(get(node, 'object.callee.property.name'));
+  const calleeNameIsJquery = allJqueryAliases.includes(get(node, 'object.callee.name'));
+  const objectNameisJquery = allJqueryAliases.includes(get(node, 'object.name'));
 
   return calleePropertyNameisJquery
     || calleeNameIsJquery
-    || calleeNameIsLocalJquery
-    || objectNameisLocalJquery;
+    || objectNameisJquery;
 }
 
 /**
@@ -21,7 +29,7 @@ function isJQueryCallee(node, name = null) {
  */
 function getVarAssignmentName(node) {
   // Get the name of what was assigned to the variable.
-  return get(node, 'init.callee.property.name') || get(node, 'init.name');
+  return get(node, 'init.callee.property.name') || get(node, 'init.name') || get(node, 'init.property.name');
 }
 
 /**
@@ -31,7 +39,7 @@ function getVarAssignmentName(node) {
  */
 function isVarAssignmentCalleeEmber(node) {
   // A variable's callee object's name tells us whether this is a usage of Ember.$ or global $.
-  const isVarCalleeObjNameEmber = get(node, 'init.callee.object.name') === 'Ember';
+  const isVarCalleeObjNameEmber = get(node, 'init.callee.object.name') === 'Ember' || get(node, 'init.object.name') === 'Ember';
   // Whether or not the callee oject is `this.$`.
   const isVarCalleeObjThis = get(node, 'init.callee.object.type') === 'ThisExpression';
 

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -13,8 +13,48 @@ ruleTester.run('no-global-jquery', rule, {
       code: `
         export default Component.extend({
           focusWithJQuery() {
+            const $ = Ember.$;
+            $('.class').focus();
+          }
+        })`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Component.extend({
+          focusWithJQuery() {
+            const Jquery = Ember.$;
+            Jquery('.class').focus();
+          }
+        })`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Component.extend({
+          focusWithJQuery() {
             const find = Ember.$;
             find('.class').focus();
+          }
+        })`,
+      parserOptions
+    },
+    {
+      code: `
+        const $ = Ember.$;
+        export default Component.extend({
+          focusWithJQuery() {
+            $('.class').focus();
+          }
+        })`,
+      parserOptions
+    },
+    {
+      code: `
+        const jQuery = Ember.$;
+        export default Component.extend({
+          focusWithJQuery() {
+            jQuery('.class').focus();
           }
         })`,
       parserOptions
@@ -54,6 +94,28 @@ ruleTester.run('no-global-jquery', rule, {
           actions: {
             valid4() {
               this.v4 = this.$('v4');
+            }
+          }
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            valid4() {
+              const elem = this.$();
+            }
+          }
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            valid4() {
+              const classElem = this.$('.class');
             }
           }
         });`,
@@ -247,6 +309,92 @@ ruleTester.run('no-global-jquery', rule, {
           nonJQueryStuff() {
             let find = document.querySelector;
             find('.class').focus();
+          }
+        })`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Component.extend({
+          nonJQueryStuff() {
+            let find = document.querySelector;
+            find('.class').focus();
+
+          },
+
+          doStuffWithJQuery() {
+            let find = jQuery;
+            find('.class').focus();
+          }
+        })`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        let find = Ember.$;
+        export default Component.extend({
+          nonJQueryStuff() {
+            let find = document.querySelector;
+            find('.class').focus();
+
+          },
+
+          doStuffWithJQuery() {
+            let find = jQuery;
+            find('.class').focus();
+          }
+        })`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        let find = $;
+        export default Component.extend({
+          nonJQueryStuff() {
+            let find = document.querySelector;
+            find('.class').focus();
+
+          },
+
+          doStuffWithJQuery() {
+            find('.class').focus();
+          }
+        })`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const $ = jQuery;
+        export default Component.extend({
+          focusWithJQuery() {
+            let $ = Ember.$;
+            $('.class').focus();
+          }
+        })`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const $ = Ember.$;
+        export default Component.extend({
+          focusWithJQuery() {
+            let $ = $;
+            $('.class').focus();
           }
         })`,
       parserOptions,

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -11,33 +11,13 @@ ruleTester.run('no-global-jquery', rule, {
   valid: [
     {
       code: `
-        import Ember from 'ember';
-        const $ = Ember.$;
-
-        export default Ember.Component({
-          func() {
-            $('.class').focus();
+        export default Component.extend({
+          focusWithJQuery() {
+            const find = Ember.$;
+            find('.class').focus();
           }
-        });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
-    },
-    {
-      code: `
-        import Ember from 'ember';
-        const jQuery = Ember.$;
-
-        export default Ember.Component({
-          func() {
-            jQuery('.class').focus();
-          }
-        });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
+        })`,
+      parserOptions
     },
     {
       code: `
@@ -90,10 +70,7 @@ ruleTester.run('no-global-jquery', rule, {
             this.el = $('.test');
           }
         });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
+      parserOptions
     },
     {
       code: `
@@ -108,10 +85,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
+      parserOptions
     },
     {
       code: `
@@ -124,10 +98,7 @@ ruleTester.run('no-global-jquery', rule, {
             this.el = foo('.test');
           }
         });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
+      parserOptions
     },
     {
       code: `
@@ -142,10 +113,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
+      parserOptions
     }
   ],
   invalid: [
@@ -196,6 +164,91 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const jayQuery = $;
+        export default Ember.Component({
+          badFun() {
+            jayQuery('.class');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const jayQuery = $;
+        export default Ember.Component({
+          badFun() {
+            jayQuery.ajax();
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const jayQuery = jQuery;
+        export default Ember.Component({
+          badFun() {
+            jayQuery('.class');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const jayQuery = jQuery;
+        export default Ember.Component({
+          badFun() {
+            jayQuery.ajax();
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          func() {
+            let a = jQuery;
+            let b = 'notDollarSign';
+
+            a('.find-me').click();
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Component.extend({
+          doStuffWithJQuery() {
+            let find = jQuery;
+            find('.class').focus();
+          },
+
+          nonJQueryStuff() {
+            let find = document.querySelector;
+            find('.class').focus();
+          }
+        })`,
       parserOptions,
       errors: [{
         message: MESSAGE

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -11,6 +11,36 @@ ruleTester.run('no-global-jquery', rule, {
   valid: [
     {
       code: `
+        import Ember from 'ember';
+        const $ = Ember.$;
+
+        export default Ember.Component({
+          func() {
+            $('.class').focus();
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+        const jQuery = Ember.$;
+
+        export default Ember.Component({
+          func() {
+            jQuery('.class').focus();
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
         export default Ember.Component({
           valid1() {
             this.v1 = Ember.$('.v1');

--- a/tests/lib/rules/no-jquery-methods.js
+++ b/tests/lib/rules/no-jquery-methods.js
@@ -218,6 +218,67 @@ ruleTester.run('no-jquery-methods', rule, {
       errors: [{
         message: getMessage(`$.${BLACKLISTMETHOD}()`)
       }]
+    },
+    {
+      code: `
+        import jQ from 'jquery';
+        const jayQuery = Ember.$;
+
+        jayQuery('.class').add();
+        jQ('.class2').add();`,
+      options: [BLACKLISTMETHOD],
+      errors: [
+        { message: getMessage(BLACKLISTMETHOD) },
+        { message: getMessage(BLACKLISTMETHOD) }
+      ]
+    },
+    {
+      code: `
+        function func1() {
+          const jayQuery = Bar.foo;
+          jayQuery().add();
+        }
+
+        function func2() {
+          const jayQuery = Ember.$;
+          jayQuery().add();
+        }
+
+        function func3() {
+          const jayQuery = Obj.method;
+          jayQuery().add();
+        }
+
+        function func4() {
+          const jayQuery = $;
+          jayQuery().add();
+        }
+
+        function func5() {
+          const jayQuery = Foo.bar;
+          jayQuery().add();
+        }`,
+      options: [BLACKLISTMETHOD],
+      errors: [
+        { message: getMessage(BLACKLISTMETHOD) },
+        { message: getMessage(BLACKLISTMETHOD) }
+      ]
+    },
+    {
+      code: `
+        import jQ from 'jquery';
+        function func1() {
+          const jayQuery = Ember.$;
+          jayQuery().add();
+        }
+
+        jQ().add();
+      `,
+      options: [BLACKLISTMETHOD],
+      errors: [
+        { message: getMessage(BLACKLISTMETHOD) },
+        { message: getMessage(BLACKLISTMETHOD) }
+      ]
     }
   ]
 });


### PR DESCRIPTION
```js
// This currently fails
const $ = Ember.$;
$(...); // flagged as global jQuery
```

this PR:
* Fixes #85 
* adds tests
* moves the following logic to util
  * logic to determine if jQuery is the callee
  * array if jquery aliases
  * function to determine if variable assignment is jQuery