### PR TITLE
Updated `no-broken-super-chain` rule[ to account for more lifecycle hooks …

### DIFF
--- a/lib/rules/no-broken-super-chain.js
+++ b/lib/rules/no-broken-super-chain.js
@@ -3,92 +3,106 @@
  */
 
 const MESSAGES = {
-  noSuper: '\'this._super(...arguments)\' must be called in init()',
-  noThisBeforeSuper: 'Must call \'this._super(...arguments)\' before accessing `this`',
-  tooManySupers: 'Only call `this._super(...arguments)` once per init()'
+  noSuper: '`this._super(...arguments)` must be called in',
+  tooManySupers: 'Only call `this._super(...arguments)` once per lifecycle hook',
+  argsNotPassedToSuper: '...arguments need to be passed to this._super() call'
 };
 
-// TODO: Make this configurable
-const EMBER_MODULES_WITH_SUPER_CHAIN = {
-  Component: true,
-  Mixin: true,
-  Route: true,
-  Controller: true,
-  View: true
-};
+const LIFECYCLE_HOOKS = ['init', 'willDestroy', 'willDestroyElement', 'destroy'];
 
-/**
- * Determines if this is an init method in an extension of Ember[EMBER_MODULES_WITH_SUPER_CHAIN.*]
- * @param {Node} node
- */
-function isInit(node) {
-  if (node.type === 'FunctionExpression' && node.parent && node.parent.key && node.parent.key.name === 'init') {
+function isExtend(node) {
+  return node && node.callee && node.callee.property && node.callee.property.name === 'extend';
+}
 
-    if (node.parent.parent
-      && node.parent.parent.parent
-      && node.parent.parent.parent.callee
-      && node.parent.parent.parent.callee.object
-      && node.parent.parent.parent.callee.object.object
-      && node.parent.parent.parent.callee.object.object.name === 'Ember') {
-      return (node.parent.parent.parent.callee.object.property
-        && EMBER_MODULES_WITH_SUPER_CHAIN[node.parent.parent.parent.callee.object.property.name]);
-    }
+function isSuperCall(lineWithinFn) {
+  if (lineWithinFn.type !== 'MemberExpression') {
+    return false;
   }
 
-  return false;
+  let isSuperCall = false;
+
+  if (lineWithinFn.object.type === 'ThisExpression') {
+    isSuperCall = lineWithinFn.property.type === 'Identifier' && lineWithinFn.property.name === '_super';
+  } else if (lineWithinFn.object.type === 'MemberExpression') {
+    isSuperCall = lineWithinFn.object.property.name === '_super';
+  }
+
+  return isSuperCall;
+}
+
+function wereArgumentsPassedToSuper(expression) {
+  const callee = expression.callee;
+
+  if (!expression || callee.type !== 'MemberExpression') {
+    return;
+  }
+
+  if (callee.property.name === '_super') {
+    const firstArgumentToSuper = expression.arguments[0];
+    return firstArgumentToSuper && firstArgumentToSuper.type === 'SpreadElement' && firstArgumentToSuper.argument.name === 'arguments';
+  } else if (callee.property.name === 'apply') {
+    const args = expression.arguments;
+    return args.length >= 2 && args[0].type === 'ThisExpression' && args[1].name === 'arguments';
+  }
 }
 
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent the absence of `this._super(...arguments)` in `init()` calls or the use of `this` prior to `this._super()`',
+      description: 'Prevent the absence of `this._super(...arguments)` in calls to various lifecycle hooks or the use of `this` prior to `this._super()`',
       category: 'Best Practices',
       recommended: true
     },
     messages: MESSAGES
   },
   create(context) {
-    let initOverride = null;
-
     return {
-      onCodePathStart(codePath, node) {
-        if (isInit(node)) {
-          initOverride = {
-            superCalled: false,
-            superCalledFirst: false
-          };
-        }
-      },
-      onCodePathEnd(codePath, node) {
-        if (initOverride && isInit(node)) { // TODO: Maybe check against codepath.name
-          if (!initOverride.superCalled) {
-            context.report({
-              message: MESSAGES.noSuper,
-              node
-            });
-          }
+      CallExpression(node) {
+        if (isExtend(node)) {
+          let superCount = 0;
+          const extendedObjects = node.arguments;
 
-          initOverride = null;
+          extendedObjects.forEach(extendedObj => {
+            extendedObj.properties.forEach(property => {
+              if (LIFECYCLE_HOOKS.includes(property.key.name)) {
+                const propertyFnBody = property.value.body;
+
+                if (propertyFnBody && propertyFnBody.body) {
+                  let expression;
+                  property.value.body.body.forEach(fnBody => {
+                    expression = fnBody.expression;
+                    if (expression.type === 'CallExpression') {
+                      const line = expression.callee;
+                      if (isSuperCall(line)) {
+                        if (!wereArgumentsPassedToSuper(expression)) {
+                          context.report({
+                            node: fnBody,
+                            message: context.meta.messages.argsNotPassedToSuper
+                          });
+                        }
+                        superCount++;
+                      }
+                    }
+                  });
+
+                  if (superCount === 0) {
+                    context.report({
+                      node: property,
+                      message: `${context.meta.messages.noSuper} ${property.key.name}`
+                    });
+                  } else if (superCount > 1) {
+                    context.report({
+                      node: property,
+                      message: context.meta.messages.tooManySupers
+                    });
+                  }
+
+                  superCount = 0;
+                }
+              }
+            });
+          });
         }
-        return;
-      },
-      'CallExpression:exit'(node) {
-        if (initOverride) {
-          const property = node.callee.property;
-          if (property && property.type === 'Identifier' && property.name === '_super') {
-            if (initOverride.superCalled) {
-              context.report({
-                message: MESSAGES.tooManySupers,
-                node
-              });
-            } else {
-              initOverride.superCalled = true;
-            }
-          }
-        }
-      },
-      'Program:exit'() {
-        initOverride = null;
       }
     };
   }


### PR DESCRIPTION
…and more object types. The rule now checks any object that's using `extend`, and validates the `init`, `willDestroy`, `destroy` and `willDestroyElement` hooks. In addition, I updated the rule to validate that `arguments` were correctly passed to the super call. Both of the below pass the rule:

`this._super(...arguments);`
`this._super.apply(this, arguments)`