### PR TITLE
[BUG FIX] Cannot read property `getFilename` of undefined

### DIFF
--- a/lib/rules/require-ember-lifeline.js
+++ b/lib/rules/require-ember-lifeline.js
@@ -30,7 +30,7 @@ function mergeDisallowedCalls(objects) {
 }
 
 function isLintableFile(context) {
-  return LINTABLE_FILE_PATTERNS.test(context.eslint.getFilename());
+  return LINTABLE_FILE_PATTERNS.test(context.getFilename());
 }
 
 module.exports = {


### PR DESCRIPTION
When I bumped our project to use Eslint 4, I started running into this error:

TypeError: Cannot read property 'getFilename' of undefined
at isLintableFile (/node_modules/eslint-plugin-ember-best-practices/lib/rules/require-ember-lifeline.js:33:53)
at MemberExpression (/node_modules/eslint-plugin-ember-best-practices/lib/rules/require-ember-lifeline.js:69:14)
at listeners.(anonymous function).forEach.listener (/node_modules/eslint/lib/util/safe-emitter.js:47:58)
at Array.forEach (<anonymous>)