### PR TITLE
Adding no-test-file-importing rule

### DIFF
--- a/guides/rules/no-test-file-importing.md
+++ b/guides/rules/no-test-file-importing.md
@@ -1,0 +1,44 @@
+# No importing of test files
+
+**TL;DR** Do not import "-test.js" file in a test file. This will cause the module and tests from the imported file to be executed aga
+
+Due to how qunit unloads a test module, importing a test file will cause any modules and tests within the file to be executed every time it gets loaded. If you want to import any helper methods or tests to be shared between multiple test files, please make it a test-helper that gets imported by the test file.
+
+```javascript
+// GOOD
+
+import setupModule from './some-test-helper';
+import { module, test } from 'qunit';
+
+module('Acceptance | module', setupModule());
+```
+
+```javascript
+// BAD
+
+import setupModule from './some-other-test';
+import { module, test } from 'qunit';
+
+module('Acceptance | module', setupModule());
+```
+
+```javascript
+// BAD
+
+import {
+  beforeEachSetup,
+  testMethod,
+} from './some-other-test';
+import { module, test } from 'qunit';
+
+module('Acceptance | module', beforeEachSetup());
+```
+
+```javascript
+// BAD
+
+import testModule from '../../test-dir/another-test';
+import { module, test } from 'qunit';
+
+module('Acceptance | module', testModule());
+```

--- a/lib/rules/no-test-file-importing.js
+++ b/lib/rules/no-test-file-importing.js
@@ -7,38 +7,6 @@
 const REPORT_MESSAGE
   = 'Do not import "-test.js" file in a test file. This will cause the module and tests from the imported file to be executed again.';
 
-/**
- * Returns the name of the module imported or re-exported.
- *
- * @param {ASTNode} node - A node to get.
- * @returns {string} the name of the module, or empty string if no name.
- */
-function getValue(node) {
-  if (node && node.source && node.source.value) {
-    return node.source.value.trim();
-  }
-
-  return '';
-}
-
-/**
- * Checks if the name of the import has '-test' in it, and reports if so.
- *
- * @param {ASTNode} importDeclaration - The importDeclaration node.
- * @returns {void} No return value
- */
-function validateImport(importDeclaration, context) {
-  const importSource = getValue(importDeclaration);
-  const re = /.*-test$/i;
-
-  if (importSource.match(re)) {
-    context.report({
-      message: REPORT_MESSAGE,
-      node: importDeclaration
-    });
-  }
-}
-
 module.exports = {
   docs: {
     description:
@@ -53,7 +21,14 @@ module.exports = {
   create: function create(context) {
     return {
       ImportDeclaration(node) {
-        validateImport(node, context);
+        const importSource = node.source.value;
+
+        if (importSource.endsWith('-test')) {
+          context.report({
+            message: REPORT_MESSAGE,
+            node
+          });
+        }
       }
     };
   }

--- a/lib/rules/no-test-file-importing.js
+++ b/lib/rules/no-test-file-importing.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview no importing of test files are allowed
+ * @author Stephen Yeung
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const REPORT_MESSAGE =
+  'Do not import "-test.js" file in a test file. This will cause the module and tests from the imported file to be executed again.';
+
+/**
+ * Returns the name of the module imported or re-exported.
+ *
+ * @param {ASTNode} node - A node to get.
+ * @returns {string} the name of the module, or empty string if no name.
+ */
+function getValue(node) {
+  if (node && node.source && node.source.value) {
+    return node.source.value.trim();
+  }
+
+  return '';
+}
+
+/**
+ * Checks if the name of the import has '-test' in it, and reports if so.
+ *
+ * @param {ASTNode} importDeclaration - The importDeclaration node.
+ * @returns {void} No return value
+ */
+function validateImport(importDeclaration, context) {
+  const importSource = getValue(importDeclaration);
+  const re = /.*-test$/i;
+
+  if (importSource.match(re)) {
+    context.report({
+      message: REPORT_MESSAGE,
+      node: importDeclaration,
+    });
+  }
+}
+
+module.exports = {
+  docs: {
+    description:
+      'Disallow importing of "-test.js" in a test file, which causes the module and tests from the imported file to be executed again.',
+    category: 'Testing',
+    recommended: false,
+  },
+  meta: {
+    message: REPORT_MESSAGE,
+  },
+
+  create: function create(context) {
+    return {
+      ImportDeclaration(node) {
+        validateImport(node, context);
+      },
+    };
+  },
+};

--- a/lib/rules/no-test-file-importing.js
+++ b/lib/rules/no-test-file-importing.js
@@ -1,16 +1,11 @@
 /**
- * @fileoverview no importing of test files are allowed
- * @author Stephen Yeung
+ * @fileOverview no importing of test files are allowed
  */
 
 'use strict';
 
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
-
-const REPORT_MESSAGE =
-  'Do not import "-test.js" file in a test file. This will cause the module and tests from the imported file to be executed again.';
+const REPORT_MESSAGE
+  = 'Do not import "-test.js" file in a test file. This will cause the module and tests from the imported file to be executed again.';
 
 /**
  * Returns the name of the module imported or re-exported.
@@ -39,7 +34,7 @@ function validateImport(importDeclaration, context) {
   if (importSource.match(re)) {
     context.report({
       message: REPORT_MESSAGE,
-      node: importDeclaration,
+      node: importDeclaration
     });
   }
 }
@@ -49,17 +44,17 @@ module.exports = {
     description:
       'Disallow importing of "-test.js" in a test file, which causes the module and tests from the imported file to be executed again.',
     category: 'Testing',
-    recommended: false,
+    recommended: false
   },
   meta: {
-    message: REPORT_MESSAGE,
+    message: REPORT_MESSAGE
   },
 
   create: function create(context) {
     return {
       ImportDeclaration(node) {
         validateImport(node, context);
-      },
+      }
     };
-  },
+  }
 };

--- a/tests/lib/rules/no-test-file-importing.js
+++ b/tests/lib/rules/no-test-file-importing.js
@@ -4,8 +4,8 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
-    sourceType: 'module',
-  },
+    sourceType: 'module'
+  }
 });
 
 ruleTester.run('no-test-file-importing', rule, {
@@ -16,8 +16,8 @@ ruleTester.run('no-test-file-importing', rule, {
         import { module, test } from 'qunit';
 
         module('Acceptance | module', setupModule());
-      `,
-    },
+      `
+    }
   ],
   invalid: [
     {
@@ -29,9 +29,9 @@ ruleTester.run('no-test-file-importing', rule, {
       `,
       errors: [
         {
-          message: MESSAGE,
-        },
-      ],
+          message: MESSAGE
+        }
+      ]
     },
     {
       code: `
@@ -45,9 +45,9 @@ ruleTester.run('no-test-file-importing', rule, {
       `,
       errors: [
         {
-          message: MESSAGE,
-        },
-      ],
+          message: MESSAGE
+        }
+      ]
     },
     {
       code: `
@@ -58,9 +58,9 @@ ruleTester.run('no-test-file-importing', rule, {
       `,
       errors: [
         {
-          message: MESSAGE,
-        },
-      ],
-    },
-  ],
+          message: MESSAGE
+        }
+      ]
+    }
+  ]
 });

--- a/tests/lib/rules/no-test-file-importing.js
+++ b/tests/lib/rules/no-test-file-importing.js
@@ -1,0 +1,66 @@
+const rule = require('../../../lib/rules/no-test-file-importing');
+const MESSAGE = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-test-file-importing', rule, {
+  valid: [
+    {
+      code: `
+        import setupModule from './some-test-helper';
+        import { module, test } from 'qunit';
+
+        module('Acceptance | module', setupModule());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import setupModule from './some-other-test';
+        import { module, test } from 'qunit';
+
+        module('Acceptance | module', setupModule());
+      `,
+      errors: [
+        {
+          message: MESSAGE,
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          beforeEachSetup,
+          testName,
+        } from './some-other-test';
+        import { module, test } from 'qunit';
+
+        module('Acceptance | module', beforeEachSetup());
+      `,
+      errors: [
+        {
+          message: MESSAGE,
+        },
+      ],
+    },
+    {
+      code: `
+        import testModule from '../../test-dir/another-test';
+        import { module, test } from 'qunit';
+
+        module('Acceptance | module', testModule());
+      `,
+      errors: [
+        {
+          message: MESSAGE,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adding no-test-file-importing rule

This prevents test files from being imported, which can cause duplicate execution of modules and tests from the test file being imported.